### PR TITLE
Clamp CanvasGroup DOFade target value

### DIFF
--- a/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUI.cs
+++ b/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUI.cs
@@ -28,6 +28,8 @@ namespace DG.Tweening
         /// <param name="endValue">The end value to reach</param><param name="duration">The duration of the tween</param>
         public static TweenerCore<float, float, FloatOptions> DOFade(this CanvasGroup target, float endValue, float duration)
         {
+            if (endValue < 0) endValue = 0;
+            else if (endValue > 1) endValue = 1;
             TweenerCore<float, float, FloatOptions> t = DOTween.To(() => target.alpha, x => target.alpha = x, endValue, duration);
             t.SetTarget(target);
             return t;


### PR DESCRIPTION
## Summary
- prevent CanvasGroup.DOFade from accepting out-of-range alpha values by clamping input between 0 and 1

## Testing
- `dotnet build` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689d9efe0728832ba488cfbc3deb7339